### PR TITLE
Only show "website/" level index pages

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -5,7 +5,14 @@ const WorkingGroupList = () => (
   <StaticQuery
     query={graphql`
       {
-        allWorkingGroupPage(filter: { file: { name: { eq: "index" } } }) {
+        allWorkingGroupPage(
+          filter: {
+            file: {
+              name: { eq: "index" }
+              relativeDirectory: { eq: "website" }
+            }
+          }
+        ) {
           nodes {
             workingGroup {
               name


### PR DESCRIPTION
This prevents working groups with multiple index pages from coming up multiple times on the home page of the site